### PR TITLE
Remove requirement for goimports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,11 @@ test:
 	go test -cover ./...
 
 install-sqlboiler:
-	go install golang.org/x/tools/cmd/goimports@latest
 	go install github.com/volatiletech/sqlboiler/v4@v4.12.0
 	go install github.com/volatiletech/sqlboiler/v4/drivers/sqlboiler-psql@v4.12.0
 
 generate-sqlboiler:
 	sqlboiler psql
-	goimports -w models/*.go
 
 generate-mocks:
 	docker compose run --rm mockery --recursive=false --with-expecter=true --dir=postgres --name=Postgres

--- a/sqlboiler.toml
+++ b/sqlboiler.toml
@@ -1,7 +1,5 @@
 no-hooks = true
 no-tests = true
-no-rows-affected = true
-no-driver-templates = true # remove if you need to use UPSERT
 
 [psql]
   dbname  = "test"


### PR DESCRIPTION
Removing `no-driver-templates` will add the code for UPSERT which uses strconv. This makes strconv used which doesn't require it to be removed.